### PR TITLE
Update brew formulas for aspect v5.7.2

### DIFF
--- a/Formula/aspect.rb
+++ b/Formula/aspect.rb
@@ -2,15 +2,15 @@ class Aspect < Formula
   desc "Correct, fast, usable: choose three"
   homepage "https://aspect.build/cli"
   url "https://github.com/aspect-build/aspect-cli"
-  version "5.5.4"
+  version "5.7.2"
   license "Apache-2.0"
   bottle do
-    root_url "https://github.com/aspect-build/aspect-cli/releases/download/5.5.4"
-    sha256 cellar: :any_skip_relocation, monterey: "bab5c20f3c13f28b1618387a5831c03b868207f5029de27e0152a450b5596794"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "dd6bfa37d97f1e3452b76fddfd5ec2eb2cb3fcf197e12184edebcb35f273a8f2"
-    sha256 cellar: :any_skip_relocation, big_sur: "8a44abe8c6035451401e4d011585127e8ced9c6a3da200881e573097f58f48fb"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "9abcc1018ece2931d6c42fdc1415251c3b741611203fe477f833401b0c7454c6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "cf0c6a44d981831f7bcfea3e8e46e6179bd635304c74828ef4f6689c49e1ce8f"
+    root_url "https://github.com/aspect-build/aspect-cli/releases/download/5.7.2"
+    sha256 cellar: :any_skip_relocation, monterey: "15f7f6c814f7c809430b2ed7a3dab99b03a9633c3b2027e30b86510170c08ad7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "db63b4ca1dfa06254f2cfbf4939deb9bb9b3e492cd3c2b44be9ea208a93169e9"
+    sha256 cellar: :any_skip_relocation, big_sur: "5a6c69db7675b76ce8f221d8e430323050b77a58140632e623988bf359bffd53"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "e4a853a0743092ba8e0533ac8232da6c0a71e9e67d3ca8fedf08fae09fbb39f4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "779bdb5d1a36d6ced50f6ff00f9bdcc98922bac0938d900d867c561549533beb"
   end
 
   conflicts_with "bazel", because: "aspect replaces the bazel binary"


### PR DESCRIPTION
Following instructions: https://github.com/aspect-build/homebrew-aspect#updating-formulas-to-the-latest-release